### PR TITLE
[DOM-171] Fix queries that are using obsolete UserShippingLimit table column (Enabled)

### DIFF
--- a/Doppler.ContactPolicies.Api.Test/Authorization.cs
+++ b/Doppler.ContactPolicies.Api.Test/Authorization.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using Doppler.ContactPolicies.Business.Logic.DTO;
 using Doppler.ContactPolicies.Business.Logic.Services;
+using Doppler.ContactPolicies.Business.Logic.UserApiClient.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -75,9 +76,13 @@ namespace Doppler.ContactPolicies.Api.Test
             contactPoliciesMock.Setup(x => x.GetIdUserByAccountName(accountName)).ReturnsAsync(It.IsAny<int>());
             contactPoliciesMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>())).ReturnsAsync(contactPoliciesSettings);
 
+            var userFeaturesMock = new Mock<IUserFeaturesService>();
+            userFeaturesMock.Setup(x => x.HasContactPoliciesFeatureAsync(accountName)).ReturnsAsync(true);
+
             var client = _factory.WithWebHostBuilder((e) => e.ConfigureTestServices(services =>
             {
                 services.AddSingleton(contactPoliciesMock.Object);
+                services.AddSingleton(userFeaturesMock.Object);
             })).CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, url)

--- a/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
+++ b/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
@@ -193,6 +193,40 @@ namespace Doppler.ContactPolicies.Api.Test
             Assert.Contains(expectedResultAsString, contentAsString);
         }
 
+        [Theory]
+        [InlineData("test1@test.com", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518,
+            HttpStatusCode.Forbidden)]
+        public async Task
+            GetContactPoliciesSettings_Should_ReturnForbidden_When_UserHasNotContactPoliciesFeature(
+                string accountName, string token, HttpStatusCode expectedStatusCode)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var contactPoliciesMock = new Mock<IContactPoliciesService>();
+            contactPoliciesMock.Setup(x => x.GetIdUserByAccountName(accountName)).ReturnsAsync(fixture.Create<int>());
+
+            var userFeaturesMock = new Mock<IUserFeaturesService>();
+            userFeaturesMock.Setup(x => x.HasContactPoliciesFeatureAsync(accountName)).ReturnsAsync(false);
+
+            var client = _factory.WithWebHostBuilder((e) => e.ConfigureTestServices(services =>
+            {
+                services.AddSingleton(contactPoliciesMock.Object);
+                services.AddSingleton(userFeaturesMock.Object);
+            })).CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/accounts/{accountName}/settings")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+        }
+
         private ContactPoliciesSettingsDto SetUpExpectedContactPoliciesSetting(string accountName,
             out string expectedResultAsString, bool isActive)
         {

--- a/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
+++ b/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using Doppler.ContactPolicies.Business.Logic.DTO;
 using Doppler.ContactPolicies.Business.Logic.Services;
+using Doppler.ContactPolicies.Business.Logic.UserApiClient.Services;
 using Doppler.ContactPolicies.Data.Access.Entities;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -45,9 +46,13 @@ namespace Doppler.ContactPolicies.Api.Test
             contactPoliciesMock.Setup(x => x.GetIdUserByAccountName(accountName)).ReturnsAsync(expectedIdUser);
             contactPoliciesMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(expectedIdUser)).ReturnsAsync(expectedContactPoliciesDto);
 
+            var userFeaturesMock = new Mock<IUserFeaturesService>();
+            userFeaturesMock.Setup(x => x.HasContactPoliciesFeatureAsync(accountName)).ReturnsAsync(true);
+
             var client = _factory.WithWebHostBuilder((e) => e.ConfigureTestServices(services =>
             {
                 services.AddSingleton(contactPoliciesMock.Object);
+                services.AddSingleton(userFeaturesMock.Object);
             })).CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/accounts/{accountName}/settings")
@@ -114,9 +119,13 @@ namespace Doppler.ContactPolicies.Api.Test
             contactPoliciesMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(expectedIdUser))
                 .ReturnsAsync(expectedContactPoliciesDto);
 
+            var userFeaturesMock = new Mock<IUserFeaturesService>();
+            userFeaturesMock.Setup(x => x.HasContactPoliciesFeatureAsync(accountName)).ReturnsAsync(true);
+
             var client = _factory.WithWebHostBuilder((e) => e.ConfigureTestServices(services =>
             {
                 services.AddSingleton(contactPoliciesMock.Object);
+                services.AddSingleton(userFeaturesMock.Object);
             })).CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/accounts/{accountName}/settings")
@@ -159,10 +168,13 @@ namespace Doppler.ContactPolicies.Api.Test
             contactPoliciesServiceMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(expectedIdUser))
                 .ReturnsAsync(expectedContactPoliciesDto).Verifiable();
 
+            var userFeaturesMock = new Mock<IUserFeaturesService>();
+            userFeaturesMock.Setup(x => x.HasContactPoliciesFeatureAsync(accountName)).ReturnsAsync(true);
 
             var client = _factory.WithWebHostBuilder((e) => e.ConfigureTestServices(services =>
             {
                 services.AddSingleton(contactPoliciesServiceMock.Object);
+                services.AddSingleton(userFeaturesMock.Object);
             })).CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/accounts/{accountName}/settings")

--- a/Doppler.ContactPolicies.Api/Controllers/ContactPolicies.cs
+++ b/Doppler.ContactPolicies.Api/Controllers/ContactPolicies.cs
@@ -29,6 +29,15 @@ namespace Doppler.ContactPolicies.Api.Controllers
             if (idUser == null)
                 return NotFound($"Account {accountName} does not exist.");
 
+            var userHasContactPoliciesFeature = await _userFeaturesService.HasContactPoliciesFeatureAsync(accountName);
+            if (!userHasContactPoliciesFeature)
+            {
+                return new ObjectResult($"User with Account {accountName} has not contact policies feature.")
+                {
+                    StatusCode = 403
+                };
+            }
+
             var contactPoliciesSettings = await _contactPoliciesService.GetContactPoliciesSettingsByIdUserAsync(idUser.Value);
 
             return new OkObjectResult(contactPoliciesSettings);

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -55,6 +55,9 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
                 from [UserShippingLimit] usl
                 where usl.IdUser = @IdUser;
 
+                if @@ROWCOUNT = 0
+                    insert into [UserShippingLimit] ([IdUser] ,[Active] ,[Amount] ,[Interval]) VALUES (@IdUser, @Active, @EmailsAmountByInterval, @IntervalInDays);";
+
             var affectedRows = await connection.ExecuteAsync(updateQuery, new
             {
                 IdUser = idUser,

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -50,7 +50,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
             using var connection = await _databaseConnectionFactory.GetConnection();
 
             using var transaction = connection.BeginTransaction();
-            const string updateQuery =
+            const string upsertQuery =
                 @"update [UserShippingLimit] set Active = @Active, Interval = @IntervalInDays, Amount = @EmailsAmountByInterval
                 from [UserShippingLimit] usl
                 where usl.IdUser = @IdUser;
@@ -58,7 +58,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
                 if @@ROWCOUNT = 0
                     insert into [UserShippingLimit] ([IdUser] ,[Active] ,[Amount] ,[Interval]) VALUES (@IdUser, @Active, @EmailsAmountByInterval, @IntervalInDays);";
 
-            var affectedRows = await connection.ExecuteAsync(updateQuery, new
+            var affectedRows = await connection.ExecuteAsync(upsertQuery, new
             {
                 IdUser = idUser,
                 contactPoliciesToInsert.IntervalInDays,

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -53,7 +53,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
             const string updateQuery =
                 @"update [UserShippingLimit] set Active = @Active, Interval = @IntervalInDays, Amount = @EmailsAmountByInterval
                 from [UserShippingLimit] usl
-                where usl.IdUser = @IdUser and usl.Enabled = 1;";
+                where usl.IdUser = @IdUser;
 
             var affectedRows = await connection.ExecuteAsync(updateQuery, new
             {

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -24,7 +24,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
             const string query =
                 @"select convert(bit, (case when usl.IdUser is null then 0 else 1 end)) as UserHasContactPolicies, usl.Active, usl.Interval [IntervalInDays], usl.Amount [EmailsAmountByInterval], u.Email [AccountName]
                 from [User] u
-                left join [UserShippingLimit] usl on u.IdUser = usl.IdUser and usl.Enabled = 1
+                left join [UserShippingLimit] usl on u.IdUser = usl.IdUser
                 where u.IdUser = @IdUser;
                 select sl.IdSubscribersList [Id], sl.Name
                 from [SubscribersListXShippingLimit] sls


### PR DESCRIPTION
Pendings: 
~~Fix current tests and include the newest to check the following commit~~ https://github.com/FromDoppler/doppler-contact-policies-api/pull/60/commits/7e6be238bab285dab336d0b9dfe7426d01a80303

Related to [DOM-171](https://makingsense.atlassian.net/browse/DOM-171)