### PR TITLE
Open db connection before transactions

### DIFF
--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -48,6 +48,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
         public async Task UpdateContactPoliciesSettingsAsync(int idUser, Entities.ContactPoliciesSettings contactPoliciesToInsert)
         {
             using var connection = _databaseConnectionFactory.GetConnection();
+            connection.Open();
 
             using var transaction = connection.BeginTransaction();
             const string upsertQuery =


### PR DESCRIPTION
The problem is when we use transaction operations (the connection is closed and in the `BeginTransaction` statement does not open):

![image](https://user-images.githubusercontent.com/75738115/155152357-64bdfd50-ef00-4fd5-a7a5-c5081743527b.png)
