### PR TITLE
Remove use of /features endpoint

### DIFF
--- a/Doppler.ContactPolicies.Business.Logic/UserApiClient/Services/UserFeaturesService.cs
+++ b/Doppler.ContactPolicies.Business.Logic/UserApiClient/Services/UserFeaturesService.cs
@@ -25,6 +25,8 @@ namespace Doppler.ContactPolicies.Business.Logic.UserApiClient.Services
             try
             {
                 var baseUri = _userFeaturesServiceSettings.UsersApiURL;
+                // TODO: remove use of this endpoint, now the "ContactPolicies" are assumed to be true for all users
+                // [related ticket](https://makingsense.atlassian.net/browse/DOP-1095)
                 var uri = new Uri(baseUri + $"/accounts/{accountName}/features");
 
                 var usersApiToken = await _usersApiTokenGetter.GetTokenAsync();


### PR DESCRIPTION
It's not necessary use this endpoint anymore because now the Contact Policies are assumed like true for all users.