### PR TITLE
Dop 1448 save n get time restriction settings

### DIFF
--- a/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
+++ b/Doppler.ContactPolicies.Api.Test/GetContactPoliciesSettingsTest.cs
@@ -161,7 +161,7 @@ namespace Doppler.ContactPolicies.Api.Test
                 ExcludedSubscribersLists = null
             };
             const string expectedResultAsString =
-                "accountName\":\"test1@test.com\",\"active\":false,\"emailsAmountByInterval\":null,\"intervalInDays\":null,\"excludedSubscribersLists\":null}";
+                "accountName\":\"test1@test.com\",\"active\":false,\"emailsAmountByInterval\":null,\"intervalInDays\":null,\"excludedSubscribersLists\":null,\"timeRestriction\":null}";
 
             var contactPoliciesServiceMock = new Mock<IContactPoliciesService>();
             contactPoliciesServiceMock.Setup(x => x.GetIdUserByAccountName(accountName)).ReturnsAsync(expectedIdUser);
@@ -249,7 +249,7 @@ namespace Doppler.ContactPolicies.Api.Test
                 }
             };
             expectedResultAsString =
-                $"{{\"accountName\":\"test1@test.com\",\"active\":{isActive.ToString().ToLower()},\"emailsAmountByInterval\":100,\"intervalInDays\":10,\"excludedSubscribersLists\":[{{\"id\":34,\"name\":\"Listado_Marketing\"}},{{\"id\":169,\"name\":\"Testing_ExcludeList\"}}]}}";
+                $"{{\"accountName\":\"test1@test.com\",\"active\":{isActive.ToString().ToLower()},\"emailsAmountByInterval\":100,\"intervalInDays\":10,\"excludedSubscribersLists\":[{{\"id\":34,\"name\":\"Listado_Marketing\"}},{{\"id\":169,\"name\":\"Testing_ExcludeList\"}}],\"timeRestriction\":null}}";
             return expectedContactPoliciesSetting;
         }
     }

--- a/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
+++ b/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
@@ -21,10 +21,15 @@ namespace Doppler.ContactPolicies.Business.Logic.Test
                 .With(x => x.AccountName, accountName)
                 .With(x => x.Active, true)
                 .Create();
+            var expectedTimeRestriction = fixture.Build<ContactPoliciesTimeRestriction>()
+                .With(x => x.AccountName, accountName)
+                .Create();
 
             var contactPoliciesRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
             contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>()))
                 .ReturnsAsync(expected).Verifiable();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesTimeRestrictionByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expectedTimeRestriction).Verifiable();
 
             var contactPoliciesSut = new ContactPoliciesService(contactPoliciesRepositoryMock.Object);
 

--- a/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
+++ b/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
@@ -55,65 +55,37 @@ namespace Doppler.ContactPolicies.Business.Logic.Test
             {
                 new ExcludedSubscribersLists() { Id = 1, Name = "Test" }
             };
-            var timeRestrictionDto = new ContactPoliciesTimeRestrictionDto()
-            {
-                TimeSlotEnabled = true,
-                HourFrom = 0,
-                HourTo = 23,
-                WeekdaysEnabled = false,
-            };
-            var contactPoliciesSettingDto = new ContactPoliciesSettingsDto()
-            {
-                AccountName = "prueba@makingsense.com",
-                Active = true,
-                EmailsAmountByInterval = 999,
-                IntervalInDays = 30,
-                ExcludedSubscribersLists = excludedLists,
-                TimeRestriction = timeRestrictionDto,
-            };
 
-            var contactPoliciesSettingExpected = new ContactPoliciesSettings()
-            {
-                AccountName = null,
-                Active = true,
-                EmailsAmountByInterval = 999,
-                IntervalInDays = 30,
-                UserHasContactPolicies = false,
-                ExcludedSubscribersLists = excludedLists,
-            };
-            var contactPoliciesTimeRestrictionExpected = new ContactPoliciesTimeRestriction()
-            {
-                TimeSlotEnabled = true,
-                HourFrom = 0,
-                HourTo = 23,
-                WeekdaysEnabled = false,
-            };
+            var fixture = new Fixture();
+            var contactPoliciesSettingsDto = fixture.Build<ContactPoliciesSettingsDto>()
+                .With(x => x.ExcludedSubscribersLists, excludedLists)
+                .Create();
 
             var contactPoliciesSettingsRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
 
             var contactPoliciesSut = new ContactPoliciesService(contactPoliciesSettingsRepositoryMock.Object);
 
             // Act
-            await contactPoliciesSut.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesSettingDto);
+            await contactPoliciesSut.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesSettingsDto);
 
             // Assert
             contactPoliciesSettingsRepositoryMock.Verify(
                 repo => repo.UpdateContactPoliciesSettingsAsync(
                     idUser,
                     It.Is<ContactPoliciesSettings>(cps =>
-                        cps.AccountName == contactPoliciesSettingExpected.AccountName
-                        && cps.Active == contactPoliciesSettingExpected.Active
-                        && cps.EmailsAmountByInterval == contactPoliciesSettingExpected.EmailsAmountByInterval
-                        && cps.IntervalInDays == contactPoliciesSettingExpected.IntervalInDays
-                        && cps.UserHasContactPolicies == contactPoliciesSettingExpected.UserHasContactPolicies
-                        && cps.ExcludedSubscribersLists.Count == contactPoliciesSettingExpected.ExcludedSubscribersLists.Count
-                        && cps.ExcludedSubscribersLists[0] == contactPoliciesSettingExpected.ExcludedSubscribersLists[0]
+                        cps.AccountName == null
+                        && cps.Active == contactPoliciesSettingsDto.Active
+                        && cps.EmailsAmountByInterval == contactPoliciesSettingsDto.EmailsAmountByInterval
+                        && cps.IntervalInDays == contactPoliciesSettingsDto.IntervalInDays
+                        && cps.UserHasContactPolicies == false
+                        && cps.ExcludedSubscribersLists.Count == contactPoliciesSettingsDto.ExcludedSubscribersLists.Count
+                        && cps.ExcludedSubscribersLists[0] == contactPoliciesSettingsDto.ExcludedSubscribersLists[0]
                     ),
                     It.Is<ContactPoliciesTimeRestriction>(cptr =>
-                        cptr.TimeSlotEnabled == contactPoliciesTimeRestrictionExpected.TimeSlotEnabled
-                        && cptr.HourFrom == contactPoliciesTimeRestrictionExpected.HourFrom
-                        && cptr.HourTo == contactPoliciesTimeRestrictionExpected.HourTo
-                        && cptr.WeekdaysEnabled == contactPoliciesTimeRestrictionExpected.WeekdaysEnabled
+                        cptr.TimeSlotEnabled == contactPoliciesSettingsDto.TimeRestriction.TimeSlotEnabled
+                        && cptr.HourFrom == contactPoliciesSettingsDto.TimeRestriction.HourFrom
+                        && cptr.HourTo == contactPoliciesSettingsDto.TimeRestriction.HourTo
+                        && cptr.WeekdaysEnabled == contactPoliciesSettingsDto.TimeRestriction.WeekdaysEnabled
                     )
                 ),
                 Times.Once

--- a/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesSettingsDto.cs
+++ b/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesSettingsDto.cs
@@ -16,5 +16,6 @@ namespace Doppler.ContactPolicies.Business.Logic.DTO
         [Required(ErrorMessage = "Interval days are required.")]
         public int? IntervalInDays { get; set; }
         public List<ExcludedSubscribersLists> ExcludedSubscribersLists { get; set; }
+        public ContactPoliciesTimeRestrictionDto TimeRestriction { get; set; }
     }
 }

--- a/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesTimeRestrictionDto.cs
+++ b/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesTimeRestrictionDto.cs
@@ -12,7 +12,7 @@ namespace Doppler.ContactPolicies.Business.Logic.DTO
         public int? HourFrom { get; set; }
 
         [Range(0, 23)]
-        [Required(ErrorMessage = "HourFrom is required.")]
+        [Required(ErrorMessage = "HourTo is required.")]
         public int? HourTo { get; set; }
 
         public bool WeekdaysEnabled { get; set; }

--- a/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesTimeRestrictionDto.cs
+++ b/Doppler.ContactPolicies.Business.Logic/DTO/ContactPoliciesTimeRestrictionDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Doppler.ContactPolicies.Business.Logic.DTO
+{
+    public class ContactPoliciesTimeRestrictionDto
+    {
+        public bool TimeSlotEnabled { get; set; }
+
+        [Range(0, 23)]
+        [Required(ErrorMessage = "HourFrom is required.")]
+        public int? HourFrom { get; set; }
+
+        [Range(0, 23)]
+        [Required(ErrorMessage = "HourFrom is required.")]
+        public int? HourTo { get; set; }
+
+        public bool WeekdaysEnabled { get; set; }
+    }
+}

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -37,5 +37,22 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
                     : new List<ExcludedSubscribersLists>(contactPoliciesSettings.ExcludedSubscribersLists)
             };
         }
+
+        public static ContactPoliciesTimeRestriction ToDao(
+            this ContactPoliciesTimeRestrictionDto contactPoliciesTimeRestrictionDto)
+        {
+            if (contactPoliciesTimeRestrictionDto == null)
+            {
+                return null;
+            }
+
+            return new ContactPoliciesTimeRestriction
+            {
+                TimeSlotEnabled = contactPoliciesTimeRestrictionDto.TimeSlotEnabled,
+                HourFrom = contactPoliciesTimeRestrictionDto.HourFrom,
+                HourTo = contactPoliciesTimeRestrictionDto.HourTo,
+                WeekdaysEnabled = contactPoliciesTimeRestrictionDto.WeekdaysEnabled
+            };
+        }
     }
 }

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -38,6 +38,23 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             };
         }
 
+        public static ContactPoliciesTimeRestrictionDto ToDto(
+            this ContactPoliciesTimeRestriction timeRestriction)
+        {
+            if (timeRestriction == null)
+            {
+                return null;
+            }
+
+            return new ContactPoliciesTimeRestrictionDto
+            {
+                TimeSlotEnabled = timeRestriction.TimeSlotEnabled,
+                HourFrom = timeRestriction.HourFrom,
+                HourTo = timeRestriction.HourTo,
+                WeekdaysEnabled = timeRestriction.WeekdaysEnabled
+            };
+        }
+
         public static ContactPoliciesTimeRestriction ToDao(
             this ContactPoliciesTimeRestrictionDto contactPoliciesTimeRestrictionDto)
         {

--- a/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
@@ -18,6 +18,10 @@ namespace Doppler.ContactPolicies.Business.Logic.Services
         {
             var contactPoliciesSettings =
                 (await _contactPoliciesSettingsRepository.GetContactPoliciesSettingsByIdUserAsync(idUser)).ToDto();
+
+            contactPoliciesSettings.TimeRestriction =
+                (await _contactPoliciesSettingsRepository.GetContactPoliciesTimeRestrictionByIdUserAsync(idUser)).ToDto();
+
             return contactPoliciesSettings;
         }
 

--- a/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
@@ -24,7 +24,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Services
         public async Task UpdateContactPoliciesSettingsAsync(int idUser, ContactPoliciesSettingsDto contactPoliciesSettings)
         {
             var contactPoliciesToUpdate = contactPoliciesSettings.ToDao();
-            await _contactPoliciesSettingsRepository.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesToUpdate);
+            var timeRestrictionToUpdate = contactPoliciesSettings.TimeRestriction.ToDao();
+            await _contactPoliciesSettingsRepository.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesToUpdate, timeRestrictionToUpdate);
         }
 
         public async Task<int?> GetIdUserByAccountName(string accountName)

--- a/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
+++ b/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
@@ -1,0 +1,12 @@
+namespace Doppler.ContactPolicies.Data.Access.Entities
+{
+    public sealed class ContactPoliciesTimeRestriction
+    {
+
+        public string AccountName { get; set; }
+        public bool TimeSlotEnabled { get; set; }
+        public int? HourFrom { get; set; }
+        public int? HourTo { get; set; }
+        public bool WeekdaysEnabled { get; set; }
+    }
+}

--- a/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
+++ b/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
@@ -2,7 +2,6 @@ namespace Doppler.ContactPolicies.Data.Access.Entities
 {
     public sealed class ContactPoliciesTimeRestriction
     {
-
         public string AccountName { get; set; }
         public bool TimeSlotEnabled { get; set; }
         public int? HourFrom { get; set; }

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -46,6 +46,26 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
             return contactPoliciesSettings;
         }
 
+        public async Task<ContactPoliciesTimeRestriction> GetContactPoliciesTimeRestrictionByIdUserAsync(int idUser)
+        {
+            using var connection = _databaseConnectionFactory.GetConnection();
+            const string query =
+                @"select
+                    ucptr.TimeSlotEnabled [TimeSlotEnabled],
+                    ucptr.HourFrom [HourFrom],
+                    ucptr.HourTo [HourTo],
+                    ucptr.WeekdaysEnabled [WeekdaysEnabled],
+                    u.Email [AccountName]
+                from [User] u
+                left join [UserContactPolicyTimeRestriction] ucptr on u.IdUser = ucptr.IdUser
+                where u.IdUser = @IdUser;";
+
+            var queryParams = new { IdUser = idUser };
+            var contactPoliciesTimeRestriction = await connection.QueryFirstOrDefaultAsync<ContactPoliciesTimeRestriction>(query, queryParams);
+
+            return contactPoliciesTimeRestriction;
+        }
+
         public async Task UpdateContactPoliciesSettingsAsync(
             int idUser,
             Entities.ContactPoliciesSettings contactPoliciesToInsert,

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -145,7 +145,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
 
             if (affectedRows == 0)
             {
-                throw new Exception($"User Contact Policy Time Restriction could not be updated");
+                throw new Exception("User Contact Policy Time Restriction could not be updated");
             }
         }
 

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
@@ -1,3 +1,4 @@
+using Doppler.ContactPolicies.Data.Access.Entities;
 using System.Threading.Tasks;
 
 namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettings
@@ -5,7 +6,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
     public interface IContactPoliciesSettingsRepository
     {
         Task<Entities.ContactPoliciesSettings> GetContactPoliciesSettingsByIdUserAsync(int idUser);
-        Task UpdateContactPoliciesSettingsAsync(int idUser, Entities.ContactPoliciesSettings contactPoliciesToInsert);
+        Task UpdateContactPoliciesSettingsAsync(int idUser, Entities.ContactPoliciesSettings contactPoliciesToInsert, ContactPoliciesTimeRestriction contactPoliciesTimeRestrictionToInsert);
         Task<int?> GetIdUserByAccountName(string accountName);
     }
 }

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
@@ -8,5 +8,6 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
         Task<Entities.ContactPoliciesSettings> GetContactPoliciesSettingsByIdUserAsync(int idUser);
         Task UpdateContactPoliciesSettingsAsync(int idUser, Entities.ContactPoliciesSettings contactPoliciesToInsert, ContactPoliciesTimeRestriction contactPoliciesTimeRestrictionToInsert);
         Task<int?> GetIdUserByAccountName(string accountName);
+        Task<ContactPoliciesTimeRestriction> GetContactPoliciesTimeRestrictionByIdUserAsync(int idUser);
     }
 }


### PR DESCRIPTION
Modify endpoints behavior to get and save the new time restriction settings into the contact policies settings.

Already available in INT: https://apisint.fromdoppler.net/contact-policies/swagger/index.html

Associated ticket: [DOP-1448](https://makingsense.atlassian.net/browse/DOP-1448)

[DOP-1448]: https://makingsense.atlassian.net/browse/DOP-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ