### PR TITLE
Dop 1492 save n get time restrictions hours in utc

### DIFF
--- a/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
+++ b/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
@@ -46,6 +46,147 @@ namespace Doppler.ContactPolicies.Business.Logic.Test
             Assert.True(actual.Active);
         }
 
+        [Theory]
+        [InlineData(22, 23, 19, 20, -180)]
+        [InlineData(1, 2, 22, 23, -180)]
+        [InlineData(22, 23, 1, 2, 180)]
+        [InlineData(1, 2, 4, 5, 180)]
+        public async Task
+            GetContactPoliciesSettings_Should_Convert_TimeRestrictionHours_To_UserTimeZone_When_OffsetMinutes_ExactHours
+            (
+                int hourFromInDB,
+                int hourToInDB,
+                int hourFromForResponse,
+                int hourToFoResponse,
+                int offsetMinutes
+            )
+        {
+            // Arrange
+            var fixture = new Fixture();
+            string accountName = "prueba@makingsense.com";
+            var expected = fixture.Build<ContactPoliciesSettings>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.Active, true)
+                .Create();
+            var expectedTimeRestriction = fixture.Build<ContactPoliciesTimeRestriction>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.HourFrom, hourFromInDB)
+                .With(x => x.HourTo, hourToInDB)
+                .With(x => x.TimeZoneOffsetMinutes, offsetMinutes)
+                .Create();
+
+            var contactPoliciesRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expected).Verifiable();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesTimeRestrictionByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expectedTimeRestriction).Verifiable();
+
+            var contactPoliciesSut = new ContactPoliciesService(contactPoliciesRepositoryMock.Object);
+
+            // Act
+            var actual = await contactPoliciesSut.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>());
+
+            // Assert
+            contactPoliciesRepositoryMock.Verify();
+            Assert.Equal(actual.AccountName, expected.AccountName);
+            Assert.True(actual.Active);
+            Assert.Equal(actual.TimeRestriction.HourFrom, hourFromForResponse);
+            Assert.Equal(actual.TimeRestriction.HourTo, hourToFoResponse);
+        }
+
+        [Theory]
+        [InlineData(22, 23, 19, 20, -150)]
+        [InlineData(1, 2, 22, 23, -150)]
+        [InlineData(22, 23, 0, 1, 150)]
+        [InlineData(1, 2, 3, 4, 150)]
+        public async Task
+            GetContactPoliciesSettings_Should_Convert_TimeRestrictionHours_To_UserTimeZone_When_OffsetMinutes_NonExactHours
+            (
+                int hourFromInDB,
+                int hourToInDB,
+                int hourFromForResponse,
+                int hourToFoResponse,
+                int offsetMinutes
+            )
+        {
+            // Arrange
+            var fixture = new Fixture();
+            string accountName = "prueba@makingsense.com";
+            var expected = fixture.Build<ContactPoliciesSettings>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.Active, true)
+                .Create();
+            var expectedTimeRestriction = fixture.Build<ContactPoliciesTimeRestriction>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.HourFrom, hourFromInDB)
+                .With(x => x.HourTo, hourToInDB)
+                .With(x => x.TimeZoneOffsetMinutes, offsetMinutes)
+                .Create();
+
+            var contactPoliciesRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expected).Verifiable();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesTimeRestrictionByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expectedTimeRestriction).Verifiable();
+
+            var contactPoliciesSut = new ContactPoliciesService(contactPoliciesRepositoryMock.Object);
+
+            // Act
+            var actual = await contactPoliciesSut.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>());
+
+            // Assert
+            contactPoliciesRepositoryMock.Verify();
+            Assert.Equal(actual.AccountName, expected.AccountName);
+            Assert.True(actual.Active);
+            Assert.Equal(actual.TimeRestriction.HourFrom, hourFromForResponse);
+            Assert.Equal(actual.TimeRestriction.HourTo, hourToFoResponse);
+        }
+
+        [Theory]
+        [InlineData(null, null, null, null, 180)]
+        [InlineData(1, 2, 1, 2, 0)]
+        public async Task GetContactPoliciesSettings_ShouldNot_Convert_TimeRestrictionHours_When_OffsetMinutesIsZero_Or_HoursAreNull
+            (
+                int? hourFromInDB,
+                int? hourToInDB,
+                int? hourFromForResponse,
+                int? hourToFoResponse,
+                int offsetMinutes
+            )
+        {
+            // Arrange
+            var fixture = new Fixture();
+            string accountName = "prueba@makingsense.com";
+            var expected = fixture.Build<ContactPoliciesSettings>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.Active, true)
+                .Create();
+            var expectedTimeRestriction = fixture.Build<ContactPoliciesTimeRestriction>()
+                .With(x => x.AccountName, accountName)
+                .With(x => x.HourFrom, hourFromInDB)
+                .With(x => x.HourTo, hourToInDB)
+                .With(x => x.TimeZoneOffsetMinutes, offsetMinutes)
+                .Create();
+
+            var contactPoliciesRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expected).Verifiable();
+            contactPoliciesRepositoryMock.Setup(x => x.GetContactPoliciesTimeRestrictionByIdUserAsync(It.IsAny<int>()))
+                .ReturnsAsync(expectedTimeRestriction).Verifiable();
+
+            var contactPoliciesSut = new ContactPoliciesService(contactPoliciesRepositoryMock.Object);
+
+            // Act
+            var actual = await contactPoliciesSut.GetContactPoliciesSettingsByIdUserAsync(It.IsAny<int>());
+
+            // Assert
+            contactPoliciesRepositoryMock.Verify();
+            Assert.Equal(actual.AccountName, expected.AccountName);
+            Assert.True(actual.Active);
+            Assert.Equal(actual.TimeRestriction.HourFrom, hourFromForResponse);
+            Assert.Equal(actual.TimeRestriction.HourTo, hourToFoResponse);
+        }
+
         [Fact]
         public async Task
             UpdateContactPoliciesSettings_Should_InvokeContactPoliciesSettingsRepository_With_ProperParameters()
@@ -87,6 +228,140 @@ namespace Doppler.ContactPolicies.Business.Logic.Test
                         cptr.TimeSlotEnabled == contactPoliciesSettingsDto.TimeRestriction.TimeSlotEnabled
                         && cptr.HourFrom == contactPoliciesSettingsDto.TimeRestriction.HourFrom
                         && cptr.HourTo == contactPoliciesSettingsDto.TimeRestriction.HourTo
+                        && cptr.WeekdaysEnabled == contactPoliciesSettingsDto.TimeRestriction.WeekdaysEnabled
+                    )
+                ),
+                Times.Once
+            );
+        }
+
+        [Theory]
+        [InlineData(22, 23, 19, 20, -180)]
+        [InlineData(1, 2, 22, 23, -180)]
+        [InlineData(22, 23, 1, 2, 180)]
+        [InlineData(1, 2, 4, 5, 180)]
+        public async Task
+            UpdateContactPoliciesSettings_Should_Convert_TimeRestrictionHours_To_UTC_When_OffsetMinutes_ExactHours
+            (
+                int hourFromForDB,
+                int hourToForDB,
+                int hourFromInRequest,
+                int hourToInRequest,
+                int offsetMinutes
+            )
+        {
+            // Arrange
+            var idUser = 1000;
+
+            var excludedLists = new List<ExcludedSubscribersLists>
+            {
+                new ExcludedSubscribersLists() { Id = 1, Name = "Test" }
+            };
+
+            var fixture = new Fixture();
+            var timeRestriction = new ContactPoliciesTimeRestrictionDto()
+            {
+                HourFrom = hourFromInRequest,
+                HourTo = hourToInRequest,
+            };
+            var contactPoliciesSettingsDto = fixture.Build<ContactPoliciesSettingsDto>()
+                .With(x => x.ExcludedSubscribersLists, excludedLists)
+                .With(x => x.TimeRestriction, timeRestriction)
+                .Create();
+
+            var contactPoliciesSettingsRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
+            contactPoliciesSettingsRepositoryMock.Setup(x => x.GetTimezoneOffsetMinutes(It.IsAny<int>()))
+                .ReturnsAsync(offsetMinutes).Verifiable();
+
+            var contactPoliciesSut = new ContactPoliciesService(contactPoliciesSettingsRepositoryMock.Object);
+
+            // Act
+            await contactPoliciesSut.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesSettingsDto);
+
+            // Assert
+            contactPoliciesSettingsRepositoryMock.Verify(
+                repo => repo.UpdateContactPoliciesSettingsAsync(
+                    idUser,
+                    It.Is<ContactPoliciesSettings>(cps =>
+                        cps.AccountName == null
+                        && cps.Active == contactPoliciesSettingsDto.Active
+                        && cps.EmailsAmountByInterval == contactPoliciesSettingsDto.EmailsAmountByInterval
+                        && cps.IntervalInDays == contactPoliciesSettingsDto.IntervalInDays
+                        && cps.UserHasContactPolicies == false
+                        && cps.ExcludedSubscribersLists.Count == contactPoliciesSettingsDto.ExcludedSubscribersLists.Count
+                        && cps.ExcludedSubscribersLists[0] == contactPoliciesSettingsDto.ExcludedSubscribersLists[0]
+                    ),
+                    It.Is<ContactPoliciesTimeRestriction>(cptr =>
+                        cptr.TimeSlotEnabled == contactPoliciesSettingsDto.TimeRestriction.TimeSlotEnabled
+                        && cptr.HourFrom == hourFromForDB
+                        && cptr.HourTo == hourToForDB
+                        && cptr.WeekdaysEnabled == contactPoliciesSettingsDto.TimeRestriction.WeekdaysEnabled
+                    )
+                ),
+                Times.Once
+            );
+        }
+
+        [Theory]
+        [InlineData(22, 23, 19, 20, -150)]
+        [InlineData(1, 2, 22, 23, -150)]
+        [InlineData(22, 23, 0, 1, 150)]
+        [InlineData(1, 2, 3, 4, 150)]
+        public async Task
+            UpdateContactPoliciesSettings_Should_Convert_TimeRestrictionHours_To_UTC_When_OffsetMinutes_NonExactHours
+            (
+                int hourFromForDB,
+                int hourToForDB,
+                int hourFromInRequest,
+                int hourToInRequest,
+                int offsetMinutes
+            )
+        {
+            // Arrange
+            var idUser = 1000;
+
+            var excludedLists = new List<ExcludedSubscribersLists>
+            {
+                new ExcludedSubscribersLists() { Id = 1, Name = "Test" }
+            };
+
+            var fixture = new Fixture();
+            var timeRestriction = new ContactPoliciesTimeRestrictionDto()
+            {
+                HourFrom = hourFromInRequest,
+                HourTo = hourToInRequest,
+            };
+            var contactPoliciesSettingsDto = fixture.Build<ContactPoliciesSettingsDto>()
+                .With(x => x.ExcludedSubscribersLists, excludedLists)
+                .With(x => x.TimeRestriction, timeRestriction)
+                .Create();
+
+            var contactPoliciesSettingsRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();
+            contactPoliciesSettingsRepositoryMock.Setup(x => x.GetTimezoneOffsetMinutes(It.IsAny<int>()))
+                .ReturnsAsync(offsetMinutes).Verifiable();
+
+            var contactPoliciesSut = new ContactPoliciesService(contactPoliciesSettingsRepositoryMock.Object);
+
+            // Act
+            await contactPoliciesSut.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesSettingsDto);
+
+            // Assert
+            contactPoliciesSettingsRepositoryMock.Verify(
+                repo => repo.UpdateContactPoliciesSettingsAsync(
+                    idUser,
+                    It.Is<ContactPoliciesSettings>(cps =>
+                        cps.AccountName == null
+                        && cps.Active == contactPoliciesSettingsDto.Active
+                        && cps.EmailsAmountByInterval == contactPoliciesSettingsDto.EmailsAmountByInterval
+                        && cps.IntervalInDays == contactPoliciesSettingsDto.IntervalInDays
+                        && cps.UserHasContactPolicies == false
+                        && cps.ExcludedSubscribersLists.Count == contactPoliciesSettingsDto.ExcludedSubscribersLists.Count
+                        && cps.ExcludedSubscribersLists[0] == contactPoliciesSettingsDto.ExcludedSubscribersLists[0]
+                    ),
+                    It.Is<ContactPoliciesTimeRestriction>(cptr =>
+                        cptr.TimeSlotEnabled == contactPoliciesSettingsDto.TimeRestriction.TimeSlotEnabled
+                        && cptr.HourFrom == hourFromForDB
+                        && cptr.HourTo == hourToForDB
                         && cptr.WeekdaysEnabled == contactPoliciesSettingsDto.TimeRestriction.WeekdaysEnabled
                     )
                 ),

--- a/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
+++ b/Doppler.ContactPolicies.Business.Logic.Test/ContactPoliciesServiceTest.cs
@@ -25,6 +25,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Test
                 .Create();
             var expectedTimeRestriction = fixture.Build<ContactPoliciesTimeRestriction>()
                 .With(x => x.AccountName, accountName)
+                .With(x => x.HourFrom, 1)
+                .With(x => x.HourTo, 2)
                 .Create();
 
             var contactPoliciesRepositoryMock = new Mock<IContactPoliciesSettingsRepository>();

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -6,6 +6,12 @@ using System.Linq;
 
 namespace Doppler.ContactPolicies.Business.Logic.Extensions
 {
+    public enum TimeZoneConversionEnum
+    {
+        CONVERT_TO_UTC,
+        CONVERT_TO_USERTIMEZONE,
+    }
+
     public static class MapperExtension
     {
         public static ContactPoliciesSettingsDto ToDto(
@@ -50,8 +56,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             return new ContactPoliciesTimeRestrictionDto
             {
                 TimeSlotEnabled = timeRestriction.TimeSlotEnabled,
-                HourFrom = ApplyHourOffset(timeRestriction.HourFrom, timeRestriction.TimeZoneOffsetMinutes, false),
-                HourTo = ApplyHourOffset(timeRestriction.HourTo, timeRestriction.TimeZoneOffsetMinutes, false),
+                HourFrom = ApplyHourOffset(timeRestriction.HourFrom, timeRestriction.TimeZoneOffsetMinutes, TimeZoneConversionEnum.CONVERT_TO_USERTIMEZONE),
+                HourTo = ApplyHourOffset(timeRestriction.HourTo, timeRestriction.TimeZoneOffsetMinutes, TimeZoneConversionEnum.CONVERT_TO_USERTIMEZONE),
                 WeekdaysEnabled = timeRestriction.WeekdaysEnabled
             };
         }
@@ -68,13 +74,13 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             return new ContactPoliciesTimeRestriction
             {
                 TimeSlotEnabled = contactPoliciesTimeRestrictionDto.TimeSlotEnabled,
-                HourFrom = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourFrom, timezoneOffsetMinutes, true),
-                HourTo = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourTo, timezoneOffsetMinutes, true),
+                HourFrom = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourFrom, timezoneOffsetMinutes, TimeZoneConversionEnum.CONVERT_TO_UTC),
+                HourTo = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourTo, timezoneOffsetMinutes, TimeZoneConversionEnum.CONVERT_TO_UTC),
                 WeekdaysEnabled = contactPoliciesTimeRestrictionDto.WeekdaysEnabled
             };
         }
 
-        private static int? ApplyHourOffset(int? hour, int offset, bool convertHourToUTC)
+        private static int? ApplyHourOffset(int? hour, int offset, TimeZoneConversionEnum conversion)
         {
             if (!hour.HasValue || offset == 0)
             {
@@ -84,7 +90,7 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             DateTime now = DateTime.Now;
             DateTime auxDate = new DateTime(now.Year, now.Month, now.Day, hour.Value, 0, 0);
 
-            int offsetMinutes = offset * (convertHourToUTC ? -1 : 1);
+            int offsetMinutes = offset * (conversion == TimeZoneConversionEnum.CONVERT_TO_UTC ? -1 : 1);
             DateTime resultDate = auxDate.AddMinutes(offsetMinutes);
 
             var hour24 = resultDate.ToString("HH");
@@ -92,7 +98,7 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             // when the offset is not an exact quantity of hours, for example: (GMT+09:30) Adelaide.
             if (resultDate.Minute > 0)
             {
-                return (int.Parse(hour24) + (convertHourToUTC ? 1 : 0)) % 24;
+                return (int.Parse(hour24) + (conversion == TimeZoneConversionEnum.CONVERT_TO_UTC ? 1 : 0)) % 24;
             }
             else
             {

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -1,5 +1,6 @@
 using Doppler.ContactPolicies.Business.Logic.DTO;
 using Doppler.ContactPolicies.Data.Access.Entities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -70,6 +71,32 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
                 HourTo = contactPoliciesTimeRestrictionDto.HourTo,
                 WeekdaysEnabled = contactPoliciesTimeRestrictionDto.WeekdaysEnabled
             };
+        }
+
+        private static int? ApplyHourOffset(int? hour, int offset, bool convertHourToUTC)
+        {
+            if (!hour.HasValue || offset == 0)
+            {
+                return hour;
+            }
+
+            DateTime now = DateTime.Now;
+            DateTime auxDate = new DateTime(now.Year, now.Month, now.Day, hour.Value, 0, 0);
+
+            int offsetMinutes = offset * (convertHourToUTC ? -1 : 1);
+            DateTime resultDate = auxDate.AddMinutes(offsetMinutes);
+
+            var hour24 = resultDate.ToString("HH");
+
+            // when the offset is not an exact quantity of hours, for example: (GMT+09:30) Adelaide.
+            if (resultDate.Minute > 0)
+            {
+                return (int.Parse(hour24) + (convertHourToUTC ? 1 : 0)) % 24;
+            }
+            else
+            {
+                return int.Parse(hour24);
+            }
         }
     }
 }

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -50,8 +50,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             return new ContactPoliciesTimeRestrictionDto
             {
                 TimeSlotEnabled = timeRestriction.TimeSlotEnabled,
-                HourFrom = timeRestriction.HourFrom,
-                HourTo = timeRestriction.HourTo,
+                HourFrom = ApplyHourOffset(timeRestriction.HourFrom, timeRestriction.TimeZoneOffsetMinutes, false),
+                HourTo = ApplyHourOffset(timeRestriction.HourTo, timeRestriction.TimeZoneOffsetMinutes, false),
                 WeekdaysEnabled = timeRestriction.WeekdaysEnabled
             };
         }

--- a/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Extensions/MapperExtension.cs
@@ -57,7 +57,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
         }
 
         public static ContactPoliciesTimeRestriction ToDao(
-            this ContactPoliciesTimeRestrictionDto contactPoliciesTimeRestrictionDto)
+            this ContactPoliciesTimeRestrictionDto contactPoliciesTimeRestrictionDto,
+            int timezoneOffsetMinutes)
         {
             if (contactPoliciesTimeRestrictionDto == null)
             {
@@ -67,8 +68,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Extensions
             return new ContactPoliciesTimeRestriction
             {
                 TimeSlotEnabled = contactPoliciesTimeRestrictionDto.TimeSlotEnabled,
-                HourFrom = contactPoliciesTimeRestrictionDto.HourFrom,
-                HourTo = contactPoliciesTimeRestrictionDto.HourTo,
+                HourFrom = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourFrom, timezoneOffsetMinutes, true),
+                HourTo = ApplyHourOffset(contactPoliciesTimeRestrictionDto.HourTo, timezoneOffsetMinutes, true),
                 WeekdaysEnabled = contactPoliciesTimeRestrictionDto.WeekdaysEnabled
             };
         }

--- a/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
+++ b/Doppler.ContactPolicies.Business.Logic/Services/ContactPoliciesService.cs
@@ -28,7 +28,8 @@ namespace Doppler.ContactPolicies.Business.Logic.Services
         public async Task UpdateContactPoliciesSettingsAsync(int idUser, ContactPoliciesSettingsDto contactPoliciesSettings)
         {
             var contactPoliciesToUpdate = contactPoliciesSettings.ToDao();
-            var timeRestrictionToUpdate = contactPoliciesSettings.TimeRestriction.ToDao();
+            var timezoneOffsetMinutes = await _contactPoliciesSettingsRepository.GetTimezoneOffsetMinutes(idUser);
+            var timeRestrictionToUpdate = contactPoliciesSettings.TimeRestriction.ToDao(timezoneOffsetMinutes);
             await _contactPoliciesSettingsRepository.UpdateContactPoliciesSettingsAsync(idUser, contactPoliciesToUpdate, timeRestrictionToUpdate);
         }
 

--- a/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
+++ b/Doppler.ContactPolicies.Data.Access/Entities/ContactPoliciesTimeRestriction.cs
@@ -7,5 +7,6 @@ namespace Doppler.ContactPolicies.Data.Access.Entities
         public int? HourFrom { get; set; }
         public int? HourTo { get; set; }
         public bool WeekdaysEnabled { get; set; }
+        public int TimeZoneOffsetMinutes { get; set; }
     }
 }

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -172,7 +172,7 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
 
             var queryParams = new { IdUser = idUser };
             var result = await connection.QueryFirstOrDefaultAsync<int?>(query, queryParams);
-            return result?? 0;
+            return result ?? 0;
         }
 
         #endregion

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -160,6 +160,21 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
             return await connection.QueryFirstOrDefaultAsync<int?>(query, queryParams);
         }
 
+        public async Task<int> GetTimezoneOffsetMinutes(int idUser)
+        {
+            using var connection = _databaseConnectionFactory.GetConnection();
+            const string query =
+                @"select
+                    utz.Offset
+                from [User] u
+                left join [UserTimeZone] utz on u.IdUserTimeZone = utz.IdUserTimeZone
+                where u.IdUser = @IdUser";
+
+            var queryParams = new { IdUser = idUser };
+            var result = await connection.QueryFirstOrDefaultAsync<int?>(query, queryParams);
+            return result?? 0;
+        }
+
         #endregion
     }
 }

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/ContactPoliciesSettingsRepository.cs
@@ -55,9 +55,11 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
                     ucptr.HourFrom [HourFrom],
                     ucptr.HourTo [HourTo],
                     ucptr.WeekdaysEnabled [WeekdaysEnabled],
-                    u.Email [AccountName]
+                    u.Email [AccountName],
+                    utz.Offset [TimeZoneOffsetMinutes]
                 from [User] u
                 left join [UserContactPolicyTimeRestriction] ucptr on u.IdUser = ucptr.IdUser
+                left join [UserTimeZone] utz on u.IdUserTimeZone = utz.IdUserTimeZone
                 where u.IdUser = @IdUser;";
 
             var queryParams = new { IdUser = idUser };

--- a/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
+++ b/Doppler.ContactPolicies.Data.Access/Repositories/ContactPoliciesSettings/IContactPoliciesSettingsRepository.cs
@@ -9,5 +9,6 @@ namespace Doppler.ContactPolicies.Data.Access.Repositories.ContactPoliciesSettin
         Task UpdateContactPoliciesSettingsAsync(int idUser, Entities.ContactPoliciesSettings contactPoliciesToInsert, ContactPoliciesTimeRestriction contactPoliciesTimeRestrictionToInsert);
         Task<int?> GetIdUserByAccountName(string accountName);
         Task<ContactPoliciesTimeRestriction> GetContactPoliciesTimeRestrictionByIdUserAsync(int idUser);
+        Task<int> GetTimezoneOffsetMinutes(int idUser);
     }
 }


### PR DESCRIPTION
The user enters the time restriction hours in his timezone, and it should be stored in the DB in UTC format. 
When the user requests this configuration, the hours obtained from the DB should be converted to the user timezone, again.